### PR TITLE
Fix gallery link in get_start page

### DIFF
--- a/get_start/index.html
+++ b/get_start/index.html
@@ -215,7 +215,7 @@ var data = require('csv?delimiter=,!./data/test.csv')
 
                     <div class="markdown-body">
                       <h4 id="install-and-setup-react-d3-packages">Install and Setup React-d3 packages</h4>
-<p>Pick one <code>react-d3</code> you want to install (see <a href="/gallery">gallery</a>). Here we are going to demo using <code>react-d3-basic</code> library to draw a simple line chart.</p>
+<p>Pick one <code>react-d3</code> you want to install (see <a href="/components">gallery</a>). Here we are going to demo using <code>react-d3-basic</code> library to draw a simple line chart.</p>
 <p>Install <code>react-d3-basic</code>:</p>
 <pre><code>npm install --save react-d3-basic
 </code></pre><h3 id="set-up-build-tools">Set up build tools</h3>


### PR DESCRIPTION
See gallery link pointed to (previous?) url `/gallery`. Change it to working url `/components`.
